### PR TITLE
Update Go install command to latest syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 Or, if you have a [Go development environment](https://golang.org/doc/install):
 
 ```
-go get -u github.com/open-pomodoro/openpomodoro-cli/cmd/pomodoro
+go install github.com/open-pomodoro/openpomodoro-cli/cmd/pomodoro@latest
 ```
 
 > If you already have another command named `pomodoro`, use `go get github.com/open-pomodoro/openpomodoro-cli` to install the `openpomodoro-cli` command.


### PR DESCRIPTION
Per CLI error:
```
'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
```